### PR TITLE
Support for multiple matching arrays.

### DIFF
--- a/lib/jsonpath-object-transform.js
+++ b/lib/jsonpath-object-transform.js
@@ -97,8 +97,11 @@
     if (seek.length && subpath) {
       result = result[key] = [];
 
-      seek[0].forEach(function(item, index) {
-        walk(item, subpath, result, index);
+      var index = 0;
+      seek.forEach(function(item){
+          item.forEach(function (item) {
+              walk(item, subpath, result, index++);
+          });
       });
     } else {
       result[key] = seek;


### PR DESCRIPTION
Added support for multiple matching arrays. Currently only the first matched array is transformed. For example:
```
var transform = require("jsonpath-object-transform");
var team = {
    members: [ 
        {
            name: "Peter",
            skills: [ 
                { name: "javascript" },
                { name: "c#" }
            ],
        },
        {
            name: "John",
            skills: [
                { name: "sql" },
                { name: "python" }
            ],
            additional: {
                skills: [
                    { name: "devops" }
                ]
            }
        }
    ]
}

var template = {
    skills: [ 
        "$..skills",
        { name: "$.name" }
    ]
};

var teamskills = transform(team, template);
```
will result in:
```
    {
        skills: [
            { name: "javascript" },
            { name: "c#" },
            { name: "sql" },
            { name: "python" },
            { name: "devops" }
        ]        
    }
```
